### PR TITLE
Mat noSorting Playlist.sol

### DIFF
--- a/PlaylistToken.sol
+++ b/PlaylistToken.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "./SongNFTfactory.sol"; 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /** PlaylistToken is a erc721 factory that creates "playlist" NFTs, empty container-items
 that keep track of a Leaderboard of songNFTs, voted by a erc20 community.
@@ -16,18 +16,19 @@ contract PlaylistToken is ERC721, ERC721Burnable, ERC721URIStorage, Ownable { //
 
     Counters.Counter private _tokenIdCounter;
     
-    ERC20 repTokenAddress; // the erc20 token we shall consider for voting
+    IERC20 private repTokenAddress; // the erc20 token we shall consider for voting
+    ERC721 songNFTAddress; // the songNFT collection we restrict the playlist to 
 
     struct Playlist { // we need a Playlist struct for new playlists
         string name;
         uint256 playlistID;
         string playlistMetadata;
-        address payable treasury;
-        uint[] songs;
+        Song[] songs;
         mapping(uint256 => Song) songsMetadata;
-        uint[][] leaderBoard;
+        mapping(uint => bool) isInLeaderBoard;
         mapping(address => uint256) voters; // keep track of the voters so the vote can be discarded.
-        mapping (bytes => uint) songsPositionsInLeaderBoard; // keep track of the index where a song is in the leaderboard, so it can easily be removed.
+        mapping (bytes => uint) songsPositionsInLeaderBoard;
+        uint256 topScore;
     }
     
     struct Song { // every songNFT info need to be added as a struct
@@ -41,20 +42,20 @@ contract PlaylistToken is ERC721, ERC721Burnable, ERC721URIStorage, Ownable { //
     
 
     modifier hasRepToken {
-        require(repTokenAddress.balanceOf(msg.sender) >= 1*10**18, "you need 1 Reputation Token at least");
+        require(repTokenAddress.balanceOf(msg.sender) >= 1, "you need 1 Reputation Token at least");
         _;
     }
     
-    constructor(address _repToken) ERC721("PlayListToken", "PlayList") {
-        repTokenAddress = ERC20(_repToken);        
+    constructor(IERC20 _repTokenAddr, address _songNFTAddr) ERC721("PlayListToken", "PlayList") {
+        repTokenAddress = _repTokenAddr; 
+        songNFTAddress = ERC721(_songNFTAddr);       
     }
 
-    function safeMint(address to, string memory _nameOfPLaylist, string memory _playlistMetadata, address payable _treasury) public onlyOwner {
+    function safeMint(address to, string memory _nameOfPLaylist, string memory _playlistMetadata) public onlyOwner {
         uint256 tokenId = _tokenIdCounter.current();        
         playlists[tokenId].name = _nameOfPLaylist;
         playlists[tokenId].playlistID = tokenId;
         playlists[tokenId].playlistMetadata = _playlistMetadata;
-        playlists[tokenId].treasury = _treasury;
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);        
     }
@@ -65,19 +66,13 @@ contract PlaylistToken is ERC721, ERC721Burnable, ERC721URIStorage, Ownable { //
         super._burn(tokenId);
     }
 
-    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory)
-    {
+    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
         return super.tokenURI(tokenId);
-    }
-
-    // change each playlist's treasury, can turn out useful for incentives
-    function changeTreasury(uint256 _playlistID, address payable _newTreasury) external onlyOwner {
-        Playlist storage playlist = playlists[_playlistID];
-        playlist.treasury = _newTreasury;
     }
     
     // create a new Song struct out of a songNFT
-    function addSong(uint256 _playlistID, address payable _creator, address _NFTcontract, uint256 _tokenId) external onlyOwner {
+    function addSong(uint256 _playlistID, address payable _creator, ERC721 _NFTcontract, uint256 _tokenId) external onlyOwner {
+        require(songNFTAddress = _NFTcontract, "Invalid NFT contract address"); // make sure the songNFT belongs to the collection we declared
         Playlist storage playlist = playlists[_playlistID];
         Song memory newsong;
         newsong.creator = _creator;
@@ -85,72 +80,63 @@ contract PlaylistToken is ERC721, ERC721Burnable, ERC721URIStorage, Ownable { //
         newsong.tokenId = _tokenId;
         newsong.score = 0;
         playlist.songsMetadata[_tokenId] = newsong;
-        playlist.songs.push(_tokenId);
+        playlist.songs.push(newsong);
+        // save the index position of the song in the leaderboard in case we have to remove it afterward.
+        playlist.songsPositionsInLeaderBoard[abi.encodePacked(_tokenId)] = playlist.songs.length - 1;
+        playlist.isInLeaderBoard[newsong.tokenId] = true;
     }
 
 
-    function upvoteSong (uint256 _playlistID, uint256 _songId) external hasRepToken {
-        // get the song.
+    function upvoteSong (uint256 _playlistID, uint256 _tokenId) external /*hasRepToken*/ {
         Playlist storage playlist = playlists[_playlistID];
-        Song storage currentSong = playlist.songsMetadata[_songId];
+        Song storage currentSong = playlist.songsMetadata[_tokenId];
+
+        require(playlist.isInLeaderBoard[currentSong.tokenId], "song not in Leaderboard");
+        currentSong.score++;
+
+        uint index = playlist.songsPositionsInLeaderBoard[abi.encodePacked(currentSong.tokenId)];
+
         
-        // increment the score and update the leaderboard.
-        updateRankByLeaderboard(playlist, currentSong, 1);
-        
-        // save the index position of the song in the leaderboard in case we have to remove it afterward.
-        playlist.songsPositionsInLeaderBoard[abi.encodePacked(currentSong.score, _songId)] = playlist.leaderBoard[currentSong.score].length;
+        playlist.songs[index].score += 1;
         
         // keep track of the voter so he/she can discard the vote.
-        playlist.voters[msg.sender] = _songId + 1; // 0 means, it's not a voter
+        playlist.voters[msg.sender] = _tokenId + 1; // 0 means, it's not a voter
         
-        // burn the token.
-        //repTokenAddress.transfer(currentSong.creator, 10*10**17); // upvoting requests msg.sender to burn 0.1 repToken. Alternatively can transfer these erc20 to the Playlist treasury
+        // upvoting requests msg.sender to burn 0.1 repToken. Alternatively can transfer these erc20 to the Playlist treasury
+        repTokenAddress.transferFrom(msg.sender, currentSong.creator, 1); 
+
+        if (currentSong.score > playlist.topScore) { // update TopScore if it is the highest
+            playlist.topScore = currentSong.score;
+        }
     }
 
-    function discardVote (uint256 _playlistID) external {
+    /* function discardVote (uint256 _playlistID) external {
         // get the playlist.
         Playlist storage playlist = playlists[_playlistID];
-        
-        // sender should already have voted in this leaderboard     
+        // sender should already have voted in this leaderboard    
         require(playlist.voters[msg.sender] > 0, "sender should be a voter");
-        
         // get the song the sender has voted for.
         uint songId = playlist.voters[msg.sender] - 1;
-
         // reinitialize msg.sender as non-voter and continue.
         playlist.voters[msg.sender] = 0;
-
         // get the song.   
         Song storage currentSong = playlist.songsMetadata[songId];
-        
-        // decrement the score and update the leaderboard.
-        updateRankByLeaderboard(playlist, currentSong, -1);
-    }
-
-    function updateRankByLeaderboard(Playlist storage playlist, Song storage song, int8 direction) internal {
-        // get the index in the leaderboard where the song is located.
-        uint index = playlist.songsPositionsInLeaderBoard[abi.encodePacked(song.score, song.tokenId)];
-        
-        // remove the song from the current leaderboard position.
-        uint[] storage songs = playlist.leaderBoard[song.score];
-        songs[index] = songs[songs.length - 1];
-        songs.pop();
-        
-        // update the score
-        if (direction == 1) {
-            song.score = song.score + 1;
-        } else {
-            song.score = song.score - 1;
-        }        
-
-        // push the song in the new position.
-        songs = playlist.leaderBoard[song.score];
-        songs.push(song.tokenId);
-    }
+        currentSong.score--;
+        playlist.songScore[currentSong.tokenId] -= 1;
+    } */
 
     function viewSong(uint256 _playlistID, uint256 _songId) external view returns(Song memory) {
         Playlist storage playlist = playlists [_playlistID];
         Song storage song = playlist.songsMetadata[_songId];
         return song;
     }
+
+
+    function getAllSongsInLeaderboard(uint _playlistID) external view returns(Song[] memory) {
+        Playlist storage playlist = playlists[_playlistID];
+        return playlist.songs;
+
+    }
+
+
 }

--- a/SongNFTfactory.sol
+++ b/SongNFTfactory.sol
@@ -18,7 +18,7 @@ contract SongNFTfactory is ERC721, ERC721URIStorage, ERC721Burnable, Ownable {
         return "link";
     }
 
-    function safeMint(address to, string memory uri) public onlyOwner {
+    function safeMint(address to, string memory mp3Uri) public onlyOwner {
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);

--- a/TheDropERC20.sol
+++ b/TheDropERC20.sol
@@ -1,116 +1,31 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/governance/Governor.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract PlaylistGovernor is Governor, GovernorSettings, GovernorCountingSimple, GovernorVotes, GovernorVotesQuorumFraction, GovernorTimelockControl {
-    constructor(string memory _nameGovernor, IVotes _token, TimelockController _timelock)
-        Governor(_nameGovernor)
-        GovernorSettings(1 /* 1 block */, 45818 /* 1 week */, 100e18)
-        GovernorVotes(_token)
-        GovernorVotesQuorumFraction(4)
-        GovernorTimelockControl(_timelock)
-    {}
+contract DropRepToken is ERC20, ERC20Burnable, Pausable, Ownable {
+    constructor() ERC20("DropRepToken", "DRP") {}
 
-    // The following functions are overrides required by Solidity.
-
-    function votingDelay()
-        public
-        view
-        override(IGovernor, GovernorSettings)
-        returns (uint256)
-    {
-        return super.votingDelay();
+    function pause() public onlyOwner {
+        _pause();
     }
 
-    function votingPeriod()
-        public
-        view
-        override(IGovernor, GovernorSettings)
-        returns (uint256)
-    {
-        return super.votingPeriod();
+    function unpause() public onlyOwner {
+        _unpause();
     }
 
-    function quorum(uint256 blockNumber)
-        public
-        view
-        override(IGovernor, GovernorVotesQuorumFraction)
-        returns (uint256)
-    {
-        return super.quorum(blockNumber);
+    function mint(address to, uint256 amount) public onlyOwner {
+        _mint(to, amount);
     }
 
-    function getVotes(address account, uint256 blockNumber)
-        public
-        view
-        override(IGovernor, GovernorVotes)
-        returns (uint256)
-    {
-        return super.getVotes(account, blockNumber);
-    }
-
-    function state(uint256 proposalId)
-        public
-        view
-        override(Governor, GovernorTimelockControl)
-        returns (ProposalState)
-    {
-        return super.state(proposalId);
-    }
-
-    function propose(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description)
-        public
-        override(Governor, IGovernor)
-        returns (uint256)
-    {
-        return super.propose(targets, values, calldatas, description);
-    }
-
-    function proposalThreshold()
-        public
-        view
-        override(Governor, GovernorSettings)
-        returns (uint256)
-    {
-        return super.proposalThreshold();
-    }
-
-    function _execute(uint256 proposalId, address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+    function _beforeTokenTransfer(address from, address to, uint256 amount)
         internal
-        override(Governor, GovernorTimelockControl)
+        whenNotPaused
+        override
     {
-        super._execute(proposalId, targets, values, calldatas, descriptionHash);
-    }
-
-    function _cancel(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
-        internal
-        override(Governor, GovernorTimelockControl)
-        returns (uint256)
-    {
-        return super._cancel(targets, values, calldatas, descriptionHash);
-    }
-
-    function _executor()
-        internal
-        view
-        override(Governor, GovernorTimelockControl)
-        returns (address)
-    {
-        return super._executor();
-    }
-
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        override(Governor, GovernorTimelockControl)
-        returns (bool)
-    {
-        return super.supportsInterface(interfaceId);
+        super._beforeTokenTransfer(from, to, amount);
     }
 }


### PR DESCRIPTION
- **SOLVED**: got rid of onChain sorting, Playlist returns a Song[] for the client to sort

- **PROBLEM**: upvoteSong() requires that the NFT address in field is == to the one in the constructor, this syntax seems not working

- **PROBLEM**: hasRepToken modifier to be tested for upvoteSong()

- **PROBLEM**: Reptoken.transferFrom(msg.sender, Song.creator, amount) requires the msg.sender to go to the RepTokenERC20.sol contract and approve() the Playlist.sol contract address. Can we create a shortcut?